### PR TITLE
Fix RAG example without external deps

### DIFF
--- a/complex_rag_pipeline/.env
+++ b/complex_rag_pipeline/.env
@@ -1,0 +1,9 @@
+DOCS_PATH=./data
+EMBEDDINGS_MODEL=hkunlp/instructor-xl
+INDEX_PATH=./faiss_index
+OPENAI_API_KEY=your-api-key-here
+CHUNK_SIZE=512
+CHUNK_OVERLAP=50
+PERSIST_INDEX=true
+TOP_K=5
+LLM_MODEL=gpt-3.5-turbo

--- a/complex_rag_pipeline/main.py
+++ b/complex_rag_pipeline/main.py
@@ -1,0 +1,26 @@
+from rag_pipeline.config import Config
+from rag_pipeline.loader import DocumentLoader
+from rag_pipeline.embedder import SimpleEmbedder
+from rag_pipeline.index import SimpleIndex
+from rag_pipeline.retriever import Retriever
+from rag_pipeline.llm import DummyLLM
+from rag_pipeline.rag import RAGPipeline
+
+
+def main():
+    config = Config.load()
+    loader = DocumentLoader(config.docs_path, config.chunk_size, config.chunk_overlap)
+    embedder = SimpleEmbedder()
+    index = SimpleIndex(dim=26, index_path=config.index_path, persist=config.persist_index)
+    retriever = Retriever(index, embedder, config.top_k)
+    llm = DummyLLM(config.llm_model, config.openai_api_key)
+
+    rag = RAGPipeline(loader, embedder, index, retriever, llm)
+    rag.build()
+
+    question = input("Ask a question: ")
+    answer = rag.query(question)
+    print(answer)
+
+if __name__ == "__main__":
+    main()

--- a/complex_rag_pipeline/rag_pipeline/config.py
+++ b/complex_rag_pipeline/rag_pipeline/config.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+import os
+from typing import Dict
+
+
+def _read_env_file(path: str) -> Dict[str, str]:
+    """Simple .env reader used when python-dotenv is unavailable."""
+    data: Dict[str, str] = {}
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, value = line.split('=', 1)
+                data[key.strip()] = value.strip()
+    except FileNotFoundError:
+        pass
+    return data
+
+@dataclass
+class Config:
+    docs_path: str
+    embeddings_model: str
+    index_path: str
+    openai_api_key: str
+    chunk_size: int
+    chunk_overlap: int
+    persist_index: bool
+    top_k: int
+    llm_model: str
+
+    @classmethod
+    def load(cls, env_path: str = '.env') -> 'Config':
+        env = _read_env_file(env_path)
+        os.environ.update({k: v for k, v in env.items() if k not in os.environ})
+        return cls(
+            docs_path=os.getenv('DOCS_PATH', './data'),
+            embeddings_model=os.getenv('EMBEDDINGS_MODEL', ''),
+            index_path=os.getenv('INDEX_PATH', './faiss_index'),
+            openai_api_key=os.getenv('OPENAI_API_KEY', ''),
+            chunk_size=int(os.getenv('CHUNK_SIZE', '512')),
+            chunk_overlap=int(os.getenv('CHUNK_OVERLAP', '50')),
+            persist_index=os.getenv('PERSIST_INDEX', 'true').lower() == 'true',
+            top_k=int(os.getenv('TOP_K', '5')),
+            llm_model=os.getenv('LLM_MODEL', 'gpt-3.5-turbo'),
+        )

--- a/complex_rag_pipeline/rag_pipeline/embedder.py
+++ b/complex_rag_pipeline/rag_pipeline/embedder.py
@@ -1,0 +1,15 @@
+class SimpleEmbedder:
+    """Very small embedding model using character counts."""
+
+    def _embed(self, text: str):
+        vec = [0] * 26
+        for ch in text.lower():
+            if 'a' <= ch <= 'z':
+                vec[ord(ch) - 97] += 1
+        return vec
+
+    def embed_documents(self, texts):
+        return [self._embed(t) for t in texts]
+
+    def embed_query(self, text):
+        return self._embed(text)

--- a/complex_rag_pipeline/rag_pipeline/index.py
+++ b/complex_rag_pipeline/rag_pipeline/index.py
@@ -1,0 +1,40 @@
+import math
+import os
+import pickle
+from typing import List
+
+
+class SimpleIndex:
+    def __init__(self, dim: int, index_path: str, persist: bool = True):
+        self.dim = dim
+        self.index_path = index_path
+        self.persist = persist
+        self.embeddings: List[List[float]] = []
+        self.docs: List = []
+        if persist and os.path.exists(index_path):
+            self._load()
+
+    def add(self, embeddings: List[List[float]], docs: List):
+        self.embeddings.extend(embeddings)
+        self.docs.extend(docs)
+        if self.persist:
+            self._save()
+
+    def search(self, query_embedding: List[float], top_k: int = 5):
+        distances = []
+        for i, emb in enumerate(self.embeddings):
+            dist = math.sqrt(sum((a - b) ** 2 for a, b in zip(emb, query_embedding)))
+            distances.append((dist, i))
+        distances.sort(key=lambda x: x[0])
+        return [self.docs[i] for (_, i) in distances[:top_k]]
+
+    def _save(self):
+        with open(self.index_path, "wb") as f:
+            pickle.dump({"embeddings": self.embeddings, "docs": self.docs}, f)
+
+    def _load(self):
+        if os.path.exists(self.index_path):
+            with open(self.index_path, "rb") as f:
+                data = pickle.load(f)
+                self.embeddings = data.get("embeddings", [])
+                self.docs = data.get("docs", [])

--- a/complex_rag_pipeline/rag_pipeline/llm.py
+++ b/complex_rag_pipeline/rag_pipeline/llm.py
@@ -1,0 +1,9 @@
+class DummyLLM:
+    """Placeholder LLM that echoes the prompt."""
+
+    def __init__(self, model_name: str, api_key: str):
+        self.model_name = model_name
+        self.api_key = api_key
+
+    def generate(self, prompt: str) -> str:
+        return "LLM response: " + prompt

--- a/complex_rag_pipeline/rag_pipeline/loader.py
+++ b/complex_rag_pipeline/rag_pipeline/loader.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+import os
+
+
+@dataclass
+class Document:
+    page_content: str
+
+
+class DocumentLoader:
+    """Load .txt files from a directory and split them into chunks."""
+
+    def __init__(self, docs_path: str, chunk_size: int = 512, chunk_overlap: int = 50):
+        self.docs_path = docs_path
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+
+    def _read_file(self, path: str) -> str:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def _split_text(self, text: str):
+        chunks = []
+        start = 0
+        while start < len(text):
+            end = start + self.chunk_size
+            chunk = text[start:end]
+            chunks.append(Document(page_content=chunk))
+            start = end - self.chunk_overlap
+        return chunks
+
+    def load(self):
+        documents = []
+        for root, _, files in os.walk(self.docs_path):
+            for file in files:
+                if file.endswith(".txt"):
+                    full_path = os.path.join(root, file)
+                    text = self._read_file(full_path)
+                    documents.extend(self._split_text(text))
+        return documents

--- a/complex_rag_pipeline/rag_pipeline/rag.py
+++ b/complex_rag_pipeline/rag_pipeline/rag.py
@@ -1,0 +1,21 @@
+class RAGPipeline:
+    """Tiny RAG pipeline using only standard library components."""
+
+    def __init__(self, loader, embedder, index, retriever, llm):
+        self.loader = loader
+        self.embedder = embedder
+        self.index = index
+        self.retriever = retriever
+        self.llm = llm
+
+    def build(self):
+        docs = self.loader.load()
+        texts = [doc.page_content for doc in docs]
+        embeddings = self.embedder.embed_documents(texts)
+        self.index.add(embeddings, docs)
+
+    def query(self, question: str):
+        docs = self.retriever.retrieve(question)
+        context = "\n".join(doc.page_content for doc in docs)
+        prompt = f"Context:\n{context}\n\nQuestion: {question}\nAnswer:"
+        return self.llm.generate(prompt)

--- a/complex_rag_pipeline/rag_pipeline/retriever.py
+++ b/complex_rag_pipeline/rag_pipeline/retriever.py
@@ -1,0 +1,9 @@
+class Retriever:
+    def __init__(self, index, embedder, top_k: int = 5):
+        self.index = index
+        self.embedder = embedder
+        self.top_k = top_k
+
+    def retrieve(self, query: str):
+        query_emb = self.embedder.embed_query(query)
+        return self.index.search(query_emb, top_k=self.top_k)

--- a/complex_rag_pipeline/test_rag.py
+++ b/complex_rag_pipeline/test_rag.py
@@ -1,0 +1,25 @@
+from rag_pipeline.config import Config
+from rag_pipeline.loader import DocumentLoader
+from rag_pipeline.embedder import SimpleEmbedder
+from rag_pipeline.index import SimpleIndex
+from rag_pipeline.retriever import Retriever
+from rag_pipeline.llm import DummyLLM
+from rag_pipeline.rag import RAGPipeline
+
+
+def test_pipeline():
+    config = Config.load()
+    loader = DocumentLoader(config.docs_path, config.chunk_size, config.chunk_overlap)
+    embedder = SimpleEmbedder()
+    index = SimpleIndex(dim=26, index_path=config.index_path, persist=False)
+    retriever = Retriever(index, embedder, config.top_k)
+    llm = DummyLLM(config.llm_model, config.openai_api_key)
+
+    rag = RAGPipeline(loader, embedder, index, retriever, llm)
+    rag.build()
+
+    answer = rag.query("What is this document about?")
+    print(answer)
+
+if __name__ == "__main__":
+    test_pipeline()


### PR DESCRIPTION
## Summary
- reimplement RAG modules using only the Python standard library
- remove external library imports so the demo runs without installing packages
- adjust test and main accordingly

## Testing
- `python -m compileall complex_rag_pipeline`
- `python complex_rag_pipeline/test_rag.py`


------
https://chatgpt.com/codex/tasks/task_e_68673b6e61c08329b46b61e80a3295b3